### PR TITLE
[Hotfix] Performance improvements for Cycle time

### DIFF
--- a/taigaProject/src/app.py
+++ b/taigaProject/src/app.py
@@ -4,8 +4,8 @@ from datetime import datetime, timedelta
 from taigaApi.auth.authenticate import authenticate
 from taigaApi.project.getProjectBySlug import get_project_by_slug
 from taigaApi.project.getProjectTaskStatusName import get_project_task_status_name
-from taigaApi.userStory.getUserStory import get_user_story
-from taigaApi.task.getTaskHistory import get_task_history
+from taigaApi.userStory.get_user_story_history import get_user_story
+from taigaApi.task.get_task_history import get_task_history
 from taigaApi.task.getTasks import get_closed_tasks
 
 

--- a/taigaProject/src/taigaApi/task/get_task_history.py
+++ b/taigaProject/src/taigaApi/task/get_task_history.py
@@ -1,4 +1,5 @@
 import os
+from concurrent.futures import ThreadPoolExecutor
 import requests
 from dotenv import load_dotenv
 from datetime import datetime
@@ -55,6 +56,34 @@ def get_task_history(tasks, auth_token):
     return [cycle_time, closed_tasks]
 
 
+def get_task_details(task, headers, taiga_url, cycle_time, closed_tasks, cycle_times):
+    task_history_url = f"{taiga_url}/history/task/{task['id']}"
+    finished_date = task["finished_date"]
+    try:
+        response = requests.get(task_history_url, headers=headers)
+        response.raise_for_status()
+        history_data = response.json()
+        in_progress_date = extract_new_to_in_progress_date(history_data)
+
+        finished_date = datetime.fromisoformat(finished_date[:-1])
+        if in_progress_date:
+            in_progress_date = datetime.fromisoformat(str(in_progress_date)[:-6])
+
+            cycle_time += (finished_date - in_progress_date).days
+            cycle_times.append({
+                "taskId": task["id"],
+                "startTime": task["created_date"],
+                "inProgressDate": in_progress_date.date(),
+                "endTime": task['finished_date'],
+                "endDate": finished_date.date(),
+                "timeTaken": (finished_date - in_progress_date).days
+            })
+            closed_tasks += 1
+
+    except requests.exceptions.RequestException as e:
+        print(f"Error fetching task by taskId: {e}")
+
+
 def get_task_lead_time(project_id, auth_token):
     tasks = get_closed_tasks(project_id, auth_token)
     lead_time = 0
@@ -102,37 +131,11 @@ def get_task_cycle_time(project_id, auth_token):
     cycle_time = 0
     closed_tasks = 0
     cycle_times = []
-
-    for task in tasks:
-        task_history_url = f"{taiga_url}/history/task/{task['id']}"
-        finished_date = task["finished_date"]
-        try:
-            response = requests.get(task_history_url, headers=headers)
-            response.raise_for_status()
-            history_data = response.json()
-
-            in_progress_date = extract_new_to_in_progress_date(history_data)
-
-            finished_date = datetime.fromisoformat(finished_date[:-1])
-            if in_progress_date:
-                in_progress_date = datetime.fromisoformat(str(in_progress_date)[:-6])
-
-                cycle_time += (finished_date - in_progress_date).days
-                cycle_times.append({
-                    "taskId": task["id"],
-                    "startTime": task["created_date"],
-                    "inProgressDate": in_progress_date.date(),
-                    "endTime": task['finished_date'],
-                    "endDate": finished_date.date(),
-                    "timeTaken": (finished_date - in_progress_date).days
-                })
-                closed_tasks += 1
-
-        except requests.exceptions.RequestException as e:
-            print(f"Error fetching task by taskId: {e}")
-
+    with ThreadPoolExecutor(max_workers=15) as executor:
+        for task in tasks:
+            executor.submit(get_task_details, task, headers, taiga_url, cycle_time, closed_tasks, cycle_times)
     if closed_tasks == 0:
         return cycle_times, 0
-    
+
     avg_cycle_time = round((cycle_time / closed_tasks), 2)
     return cycle_times, avg_cycle_time

--- a/taigaProject/src/taigaApi/util/metric_service.py
+++ b/taigaProject/src/taigaApi/util/metric_service.py
@@ -1,5 +1,5 @@
-from ..task.getTaskHistory import get_task_lead_time, get_task_cycle_time
-from ..userStory.getUserStory import get_us_lead_time, get_us_cycle_time
+from ..task.get_task_history import get_task_lead_time, get_task_cycle_time
+from ..userStory.get_user_story_history import get_us_lead_time, get_us_cycle_time
 
 
 def get_lead_time_details(project_details, auth_token):

--- a/taigaProject/test/taigaApi/test_taskHistory.py
+++ b/taigaProject/test/taigaApi/test_taskHistory.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from taigaProject.src.taigaApi.task.getTaskHistory import get_task_history
+from taigaProject.src.taigaApi.task.get_task_history import get_task_history
 
 
 # content of test_sample.py


### PR DESCRIPTION
Currently, the API response is coming in approx 1.5-2 mins [for lesly-we-play-sport], which is still a lot, but better than the last time.
Changed the file names for a couple of files, to follow the convention that we're following for all the files. 